### PR TITLE
Address #2 - Capture metadata as transaction attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,16 @@ lib-cov
 *.pid
 *.swp
 *.swo
+
+# Webstorm Settings
+.idea/*
+!.idea/inspectionProfiles
+!.idea/jsLinters
+
+# Istanbul Output
+coverage/
+
+# NPM Dependencies
 node_modules/
-.idea/
+/.project
+/dist

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ require('newrelic');
 var winston = require('winston'),
     WinstonNewrelic = require('winston-newrelic');
 
-// Add newrelic logger as trasporter
+// Add newrelic logger as transporter
 winston.add(winston.transports.newrelic, {});
 ```
 

--- a/lib/winston-newrelic.js
+++ b/lib/winston-newrelic.js
@@ -8,7 +8,7 @@ var winston = require('winston'),
  * @constructor
  * @type {Function}
  */
-var WinstonNewrelic = module.exports = function(options) {
+var WinstonNewrelic = module.exports = function WinstonNewrelic(options) {
     /**
      * Winston Trasporter Name
      * @type {string}
@@ -19,13 +19,13 @@ var WinstonNewrelic = module.exports = function(options) {
      * Default logging level is error
      * @type {string}
      */
-    this.level = options.level || 'error';
+    this.level = (options && options.level) || 'error';
 
     /**
      * Take the injected instance or require it globally
      * @type {object}
      */
-    this.newrelic = options.newrelic || require('newrelic');
+    this.newrelic = (options && options.newrelic) || this.getNewRelic();
 };
 
 /**
@@ -45,9 +45,69 @@ winston.transports.newrelic = WinstonNewrelic;
  * @param {object} meta
  * @param {function} callback
  */
-WinstonNewrelic.prototype.log = function(level, msg, meta, callback) {
-    // Should support meta next on - consider JSON.stringify
-    this.newrelic.noticeError(new Error(msg));
+WinstonNewrelic.prototype.log = function log(level, msg, meta, callback) {
+    if (typeof meta === 'function' && typeof callback !== 'function') {
+        callback = meta;
+        meta = null;
+    }
 
-    callback(null, true);
+    var logMsg = this.formatMessage(level, msg, meta);
+    this.newrelic.noticeError(logMsg.message, logMsg.customParameters);
+
+    if (typeof callback === 'function') {
+        callback(null, true);
+    }
+};
+
+/**
+ * Returns the instance of New Relic used for logging.
+ */
+WinstonNewrelic.prototype.getNewRelic = function getNewRelic() {
+    /* istanbul ignore next: mocked for test purposes */
+    return this.newrelic || require('newrelic');
+};
+
+/**
+ * Formats an error message for New Relic
+ * @param {string} level
+ * @param {string} msg
+ * @param {object} meta
+ */
+WinstonNewrelic.prototype.formatMessage = function formatMessage(level, message, meta) {
+    var logMessage = { message: message },
+        customParameters = {
+            logLevel: level
+        };
+
+    if (message instanceof Error) {
+        logMessage.message = message.message;
+        logMessage.stack = message.stack;
+    }
+    if (meta) {
+        var stack = logMessage.stack || meta.stack || (meta.error && meta.error.stack);
+        logMessage.stack = stack;
+        Object.keys(meta).forEach(
+            function forEachMeta(prop) {
+                if (prop === 'stack') { return; }
+                var val = meta[prop];
+                if (val instanceof Error) {
+                    val = val.toString();
+                }
+                else if (typeof val === 'function') {
+                    val = '[Function: ' + (val.name || '<anonymous>') + ']';
+                }
+                else if (typeof val === 'object') {
+                    val = JSON.stringify(val);
+                }
+                customParameters[prop] = val;
+            });
+    }
+    if (!logMessage.stack) {
+        logMessage.stack = (new Error()).stack;
+    }
+
+    return {
+        message: logMessage,
+        customParameters: customParameters
+    };
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Reports winston log errors to new-relic",
   "version": "0.1.3",
   "scripts": {
-    "test": "mocha -R spec test/*.js test/*.js"
+    "pretest": "node node_modules/jshint/bin/jshint ./lib/.",
+    "test": "istanbul cover ./node_modules/mocha/bin/_mocha"
   },
   "license": "MIT",
   "tags": [
@@ -20,14 +21,17 @@
     "email": "ranm@codeoasis.com"
   },
   "dependencies": {
-    "newrelic": "~1.2.0",
-    "winston": "~0.7.2"
+    "newrelic": "~1.7.1",
+    "winston": "~0.7.3"
   },
   "devDependencies": {
-    "mocha": "~1.9.0",
-    "chai": "~1.6.1",
-    "sinon": "~1.7.2",
-    "rewire": "~1.1.3"
+    "mocha": "~1.20.1",
+    "chai": "~1.9.1",
+    "sinon": "~1.10.2",
+    "rewire": "~2.0.1",
+    "istanbul": "~0.2.11",
+    "mocha-istanbul": "~0.2.0",
+    "jshint": "~2.5.1"
   },
   "repository": {
     "type": "git",

--- a/test/winston-newrelic-spec.js
+++ b/test/winston-newrelic-spec.js
@@ -17,12 +17,12 @@ describe('winston-newrelic', function() {
         /**
          * Mocks new relic object by stubbing the noticeError API method
          */
-        newrelicMock,
+            newrelicMock,
 
         /**
          * The instance to test
          */
-        instance;
+            instance;
 
     beforeEach(function() {
         winstonMock = {
@@ -35,47 +35,191 @@ describe('winston-newrelic', function() {
         };
 
         WinstonNewrelic.__set__('winston', winstonMock);
-
-        // Instantiate
-        instance = new WinstonNewrelic({
-            level: 'info',
-            newrelic: newrelicMock
-        });
     });
 
     describe('#constructor', function() {
+        var origGetNr;
+        beforeEach(function () {
+            origGetNr = WinstonNewrelic.prototype.getNewRelic;
+            WinstonNewrelic.prototype.getNewRelic = sinon.stub().returns(newrelicMock);
+        });
+
+        afterEach(function () {
+            WinstonNewrelic.prototype.getNewRelic = origGetNr;
+        });
+
         it('should set the object name to `winston-newrelic`', function() {
+            var instance = new WinstonNewrelic();
             expect(instance.name).to.equal('winston-newrelic');
         });
 
         it('should set the level to default of `error` in case none was set', function() {
-            instance = new WinstonNewrelic({
-                newrelic: newrelicMock
-            });
-
+            var instance = new WinstonNewrelic();
             expect(instance.level).to.equal('error');
         });
 
         it('should set the level according to options if given', function() {
+            var instance = new WinstonNewrelic({level: 'info'});
             expect(instance.level).to.equal('info');
+        });
+
+        it('should require newRelic if mock not provided', function() {
+            var instance = new WinstonNewrelic({level: 'info'});
+            expect(instance.getNewRelic.called).to.equal(true);
+            expect(instance.newrelic).to.equal(newrelicMock);
+        });
+
+        it('should use newRelic object if provided', function() {
+            var nr = { my: 'fakeNewrelic' };
+            var instance = new WinstonNewrelic({newrelic: nr});
+            expect(instance.getNewRelic.called).to.equal(false);
+            expect(instance.newrelic).to.equal(nr);
         });
     });
 
-    describe('#log()', function() {
-        var msg = 'just another error';
+    var msg = 'just another error';
+    describe('instance', function () {
 
-        it('should log the log message to newrelic by creating new Error() object', function() {
-            instance.log('error', msg, {}, function(){});
-
-            expect(newrelicMock.noticeError.calledWith(new Error(msg))).to.equal(true);
+        var instance;
+        beforeEach(function() {
+            // Instantiate
+            instance = new WinstonNewrelic({
+                level: 'info',
+                newrelic: newrelicMock
+            });
         });
 
-        it('should call the callback with null and true for success', function() {
-            var callback = sinon.stub();
+        describe('#log()', function() {
 
-            instance.log('error', msg, {}, callback);
+            beforeEach(function() {
+                // Instantiate
+                instance = new WinstonNewrelic({
+                    level: 'info',
+                    newrelic: newrelicMock
+                });
+            });
 
-            expect(callback.calledWith(null, true)).to.equal(true);
+
+            it('should log the log message to newrelic', function() {
+                instance.log('error', msg, {}, function(){});
+                expect(newrelicMock.noticeError.called).to.equal(true);
+            });
+
+            it('should format the message prior to calling newRelic', function() {
+                var level = 'error',
+                    meta = { custom1: 'value1', custom2: 'value2' },
+                    formatted = {
+                        message: { message: msg, stack: (new Error()).stack },
+                        customParameters: meta
+                    };
+                instance.formatMessage = sinon.stub().returns(formatted);
+                instance.log(level, msg, meta, sinon.stub());
+                expect(instance.formatMessage.calledWith(level, msg, meta)).to.equal(true);
+                expect(newrelicMock.noticeError.calledWith(formatted.message, formatted.customParameters)).to.equal(true);
+            });
+
+            it('should call the callback with null and true for success', function() {
+                var callback = sinon.stub();
+
+                instance.log('error', msg, {}, callback);
+
+                expect(callback.calledWith(null, true)).to.equal(true);
+            });
+
+            it('should allow meta to be optional', function() {
+                var cb = sinon.stub();
+                instance.log('error', msg, cb);
+                expect(newrelicMock.noticeError.called).to.equal(true);
+                expect(cb.called).to.equal(true);
+            });
+
+            it('should allow meta and callback to be optional', function() {
+                var cb = sinon.stub();
+                instance.log('error', msg);
+                expect(newrelicMock.noticeError.called).to.equal(true);
+            });
+        });
+
+        describe('#formatMessage()', function() {
+            it('should log message with level and stack', function() {
+                var level = 'warn',
+                    formatted = instance.formatMessage(level, msg);
+                expect(formatted.message).to.be.ok;
+                expect(formatted.message.message).to.equal(msg);
+                expect(formatted.message.stack).to.be.ok;
+                expect(formatted.customParameters).to.be.ok;
+                expect(formatted.customParameters.logLevel).to.equal(level);
+            });
+
+            it('should log Error with level and stack', function() {
+                var level = 'warn',
+                    errMsg = new Error(msg),
+                    formatted = instance.formatMessage(level, errMsg);
+                expect(formatted.message).to.be.ok;
+                expect(formatted.message.message).to.equal(errMsg.message);
+                expect(formatted.message.stack).to.equal(errMsg.stack);
+                expect(formatted.customParameters).to.be.ok;
+                expect(formatted.customParameters.logLevel).to.equal(level);
+            });
+
+            it('should log message with stack provided in meta', function() {
+                var level = 'warn',
+                    stack = new Error(msg).stack,
+                    meta = {
+                        stack: stack
+                    },
+                    formatted = instance.formatMessage(level, msg, meta);
+                expect(formatted.message).to.be.ok;
+                expect(formatted.message.message).to.equal(msg);
+                expect(formatted.message.stack).to.equal(meta.stack);
+                expect(formatted.customParameters).to.be.ok;
+                expect(formatted.customParameters.logLevel).to.equal(level);
+                expect(formatted.customParameters.stack).to.not.be.ok;
+            });
+
+            it('should log message with stack from error provided in meta', function() {
+                var level = 'warn',
+                    meta = {
+                        error: new Error(msg)
+                    },
+                    formatted = instance.formatMessage(level, msg, meta);
+                expect(formatted.message).to.be.ok
+                expect(formatted.message.message).to.equal(msg);
+                expect(formatted.message.stack).to.equal(meta.error.stack);
+                expect(formatted.customParameters).to.be.ok;
+                expect(formatted.customParameters.logLevel).to.equal(level);
+                expect(typeof formatted.customParameters.error).to.equal('string')
+            });
+
+            it('should pass on meta properties as custom parameters', function() {
+                var level = 'warn',
+                    meta = {
+                        string: "value",
+                        number: 12345,
+                        obj: { prop: "val" },
+                        func: function someFn() { },
+                        anonymousFunc: function () { }
+                    },
+                    formatted = instance.formatMessage(level, msg, meta);
+                expect(formatted.message).to.be.ok;
+                expect(formatted.message.message).to.equal(msg);
+                expect(formatted.message.stack).to.be.ok;
+                expect(formatted.customParameters).to.be.ok;
+                expect(formatted.customParameters.logLevel).to.equal(level);
+                expect(formatted.customParameters.string).to.equal(meta.string);
+                expect(formatted.customParameters.number).to.equal(meta.number);
+                expect(formatted.customParameters.obj).to.equal(JSON.stringify(meta.obj));
+                expect(formatted.customParameters.func).to.equal("[Function: someFn]");
+                expect(formatted.customParameters.anonymousFunc).to.equal("[Function: <anonymous>]");
+            });
+
+        });
+
+        describe('#getNewRelic()', function() {
+            it ('should return newrelic instance', function () {
+                var nr = instance.getNewRelic();
+                expect(nr).to.equal(instance.newrelic);
+            });
         });
     });
 });


### PR DESCRIPTION
This pull request adds the following functionality:
- Allow NewRelic to capture winston metadata as transaction attributes
- Added istanbul coverage - 100%
- Handle metadata containing objects/functions

![transaction attributes](https://cloud.githubusercontent.com/assets/1964119/3249120/82579420-f195-11e3-9300-b8d90ea5f6e7.jpg)
